### PR TITLE
Fix: Remove ACL parameter from S3 uploads to resolve 400 error

### DIFF
--- a/server/services/s3Service.ts
+++ b/server/services/s3Service.ts
@@ -66,7 +66,6 @@ export async function uploadFile(buffer: Buffer, fileName: string, contentType: 
         Key: key,
         Body: buffer,
         ContentType: contentType,
-        ACL: 'public-read' // Make file publicly readable
     });
 
     await s3Client.send(command);


### PR DESCRIPTION
- Fixed 'The bucket does not allow ACLs' error in avatar upload
- Removed ACL: 'public-read' parameter from S3 PutObjectCommand
- Avatar upload now works with S3 buckets that have ACLs disabled
- Resolves 400 error when trying to upload avatar images