### PR TITLE
Fix: Add missing sendRawMessage to WebSocket destructuring in messagi…

### DIFF
--- a/client/src/components/messaging/ModernMessagingInterface.tsx
+++ b/client/src/components/messaging/ModernMessagingInterface.tsx
@@ -56,7 +56,8 @@ export function ModernMessagingInterface({
     leaveRoom,
     startTyping,
     stopTyping,
-    markMessageAsRead
+    markMessageAsRead,
+    sendRawMessage
   } = webSocketState;
 
   // Fetch messages


### PR DESCRIPTION
…ng interface

- Fixed 'something went wrong' error when clicking contacts in messaging
- Added sendRawMessage to WebSocket state destructuring
- sendRawMessage is required for conversation room management
- Resolves undefined function error causing messaging interface crashes
- Users can now successfully open conversations with contacts
- WebSocket room management now works correctly for conversation rooms