### PR TITLE
Fix: Remove ReactQueryDevtools to resolve production build failure

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,7 +45,6 @@ import { MobileNav } from "@/components/MobileNav";
 import { AccountTypeSelection } from "@/pages/AccountTypeSelection";
 import { AccountTypeRoute } from "@/lib/account-type-route";
 import { CrossPlatformProvider } from "@/lib/cross-platform";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { StripeConnectProvider } from "@/contexts/stripe-connect-context";
 import { PaymentDialogManager } from "@/components/payments/PaymentDialogManager";
 import { useMobile } from "@/hooks/use-mobile";
@@ -175,7 +174,6 @@ function App() {
           </AuthProvider>
         </CrossPlatformProvider>
       </ThemeProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,7 @@
         "@replit/vite-plugin-cartographer": "^0.1.2",
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
+        "@tanstack/react-query-devtools": "^5.81.2",
         "@types/connect-pg-simple": "^7.0.3",
         "@types/express": "4.17.21",
         "@types/express-session": "^1.18.0",
@@ -10911,9 +10912,20 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.75.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.75.7.tgz",
-      "integrity": "sha512-4BHu0qnxUHOSnTn3ow9fIoBKTelh0GY08yn1IO9cxjBTsGvnxz1ut42CHZqUE3Vl/8FAjcHsj8RNJMoXvjgHEA==",
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.2.tgz",
+      "integrity": "sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz",
+      "integrity": "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10921,18 +10933,36 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.75.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.75.7.tgz",
-      "integrity": "sha512-JYcH1g5pNjKXNQcvvnCU/PueaYg05uKBDHlWIyApspv7r5C0BM12n6ysa2QF2T+1tlPnNXOob8vr8o96Nx0GxQ==",
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.2.tgz",
+      "integrity": "sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.75.7"
+        "@tanstack/query-core": "5.81.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.81.2.tgz",
+      "integrity": "sha512-TX0OQ4cbgX6z2uN8c9x0QUNbyePGyUGdcgrGnV6TYEJc7KPT8PqeASuzoA5NGw1CiMGvyFAkIGA2KipvhM9d1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.81.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.81.2",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "@replit/vite-plugin-cartographer": "^0.1.2",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
+    "@tanstack/react-query-devtools": "^5.81.2",
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4277,17 +4277,29 @@
     "@tailwindcss/oxide" "4.1.6"
     tailwindcss "4.1.6"
 
-"@tanstack/query-core@5.75.7":
-  version "5.75.7"
-  resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.75.7.tgz"
-  integrity sha512-4BHu0qnxUHOSnTn3ow9fIoBKTelh0GY08yn1IO9cxjBTsGvnxz1ut42CHZqUE3Vl/8FAjcHsj8RNJMoXvjgHEA==
+"@tanstack/query-core@5.81.2":
+  version "5.81.2"
+  resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.2.tgz"
+  integrity sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==
 
-"@tanstack/react-query@^5.60.5":
-  version "5.75.7"
-  resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.75.7.tgz"
-  integrity sha512-JYcH1g5pNjKXNQcvvnCU/PueaYg05uKBDHlWIyApspv7r5C0BM12n6ysa2QF2T+1tlPnNXOob8vr8o96Nx0GxQ==
+"@tanstack/query-devtools@5.81.2":
+  version "5.81.2"
+  resolved "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz"
+  integrity sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==
+
+"@tanstack/react-query-devtools@^5.81.2":
+  version "5.81.2"
+  resolved "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.81.2.tgz"
+  integrity sha512-TX0OQ4cbgX6z2uN8c9x0QUNbyePGyUGdcgrGnV6TYEJc7KPT8PqeASuzoA5NGw1CiMGvyFAkIGA2KipvhM9d1g==
   dependencies:
-    "@tanstack/query-core" "5.75.7"
+    "@tanstack/query-devtools" "5.81.2"
+
+"@tanstack/react-query@^5.60.5", "@tanstack/react-query@^5.81.2":
+  version "5.81.2"
+  resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.2.tgz"
+  integrity sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==
+  dependencies:
+    "@tanstack/query-core" "5.81.2"
 
 "@trysound/sax@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
- Add @tanstack/react-query-devtools as dev dependency
- Remove ReactQueryDevtools import and usage from App.tsx
- Prevents Vite build failure on Render deployment
- DevTools were causing 'unintended externalization' error in production
- App now builds successfully for production deployment